### PR TITLE
switch to extend schema

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -9,25 +9,26 @@ directive @contact(
   description: String
 ) on SCHEMA
 
-schema
+extend schema
   @contact(
     name: "Thing Server Team"
     url: "https://myteam.slack.com/archives/teams-chat-room-url"
     description: "send urgent issues to [#oncall](https://yourteam.slack.com/archives/oncall)."
-  ) {
-  query: Query
-}
+  )
 
 type Query {
   thing(id: ID!): Thing
 }
+
 type Mutation {
   createThing(thing: CreateThing!): Thing
 }
+
 type Thing @key(fields: "id") {
   id: ID!
   name: String
 }
+
 input CreateThing {
   id: ID!
   name: String


### PR DESCRIPTION
Not only is this more concise, but more correct: the `mutation` field was left off of the schema definition mutations wouldn't work.