### PR TITLE
fix: Update Node engine to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "src/index.js",
   "engines": {
-    "node": ">=14.0"
+    "node": ">=18.0"
   },
   "scripts": {
     "dev": "nodemon --ext \"js,graphql\" src/index.js",


### PR DESCRIPTION
Most new services probably want 18, and advanced users can always downgrade if they know what they need.